### PR TITLE
In perform_load change status to a uint16_t.

### DIFF
--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@ void __NOINLINE __REGPARM print(const char *s){
 }
 
 uint8_t __NOINLINE __REGPARM perform_load(const DiskAddressPacket* dap, uint16_t disk_number) {
-  uint8_t status;
+  uint16_t status;
   __asm__ __volatile__ (
     "int $0x13"
     : "=a"(status)


### PR DESCRIPTION
`status` was originally a `uint8_t` and as a result `return status>>8` always returned a 0 value even when there was an error returned in the upper 8 bits of `AX`.

With this fix you'll probably find all the Int 13h/AH=42h disk reads from floppy media were in fact failing. To read from floppy media you will need to use Int 13h/AH=2h.